### PR TITLE
feat: wire up stripe checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Prerequisites: Node.js
    - `VITE_SUBSCRIPTION_STATUS_URL=https://your-api/subscription/status`
    - `VITE_SUBSCRIPTION_VERIFY_URL=https://your-api/subscription/verify`
    - `VITE_RETURN_URL=https://your-app-url`
+   - `VITE_STRIPE_PUBLISHABLE_KEY=pk_test_XXXX`
+   - `VITE_STRIPE_CREATE_CHECKOUT_URL=https://your-api/stripe/create-checkout`
+   - `VITE_STRIPE_PAYMENT_LINK=https://buy.stripe.com/...` *(optional direct payment link)*
+   - `VITE_STRIPE_CUSTOMER_PORTAL_URL=https://billing.stripe.com/p/session/...` *(optional direct portal)*
 4. Run: `npm run dev`
 
 ## How to use (end users)

--- a/components/SubscriptionGate.ts
+++ b/components/SubscriptionGate.ts
@@ -28,11 +28,16 @@ export class SubscriptionGate extends LitElement {
 
   @property({ type: Boolean }) isSubscribed = true;
   @property({ type: String }) checkoutUrl: string | null = null;
+  @property({ type: Function }) onCheckout: (() => Promise<void>) | null = null;
   @property({ type: Function }) onVerify: (() => Promise<void>) | null = null;
 
-  private startTrial() {
-    const url = this.checkoutUrl || '#';
-    window.open(url, '_blank');
+  private async startTrial() {
+    try {
+      await this.onCheckout?.();
+    } catch {
+      const url = this.checkoutUrl || '#';
+      window.open(url, '_blank');
+    }
   }
 
   private startDemo() {

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
         }
       }
     </script>
+    <script src="https://js.stripe.com/v3"></script>
   </head>
   <body>
     <!-- PWA update -->


### PR DESCRIPTION
## Summary
- load Stripe.js in the client and add checkout callback to SubscriptionGate
- invoke backend to create Stripe checkout sessions and redirect to Stripe
- document Stripe environment variables for local setup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898edea76c08321ade64c0c9d452ad1