### PR TITLE
feat: add subscription backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ Prerequisites: Node.js
    - `VITE_STRIPE_CREATE_CHECKOUT_URL=https://your-api/stripe/create-checkout`
    - `VITE_STRIPE_PAYMENT_LINK=https://buy.stripe.com/...` *(optional direct payment link)*
    - `VITE_STRIPE_CUSTOMER_PORTAL_URL=https://billing.stripe.com/p/session/...` *(optional direct portal)*
-4. Run: `npm run dev`
+4. For the built-in subscription server set the following env vars and run `npm run server`:
+   - `STRIPE_SECRET_KEY=sk_test_XXXX`
+   - `STRIPE_PRICE_ID=price_XXXX`
+   - `SESSION_SECRET=change_me`
+   - `RETURN_URL=https://your-app-url`
+   - `ALLOWED_ORIGIN=http://localhost:5173`
+5. Run: `npm run dev`
 
 ## How to use (end users)
 

--- a/package.json
+++ b/package.json
@@ -10,12 +10,18 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server.js"
   },
   "dependencies": {
     "@google/genai": "^1.0.0",
     "lit": "^3.3.0",
-    "lamejs": "^1.2.0"
+    "lamejs": "^1.2.0",
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "express-session": "^1.17.3",
+    "morgan": "^1.10.0",
+    "stripe": "^14.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,111 @@
+import express from 'express';
+import session from 'express-session';
+import Stripe from 'stripe';
+import cors from 'cors';
+import morgan from 'morgan';
+
+const app = express();
+const port = process.env.PORT || 3000;
+const allowedOrigin = process.env.ALLOWED_ORIGIN || '*';
+const sessionSecret = process.env.SESSION_SECRET || 'deeprabbit-session';
+const stripeSecret = process.env.STRIPE_SECRET_KEY || '';
+const priceId = process.env.STRIPE_PRICE_ID || '';
+const returnUrl = process.env.RETURN_URL || 'http://localhost:5173';
+
+const stripe = stripeSecret ? new Stripe(stripeSecret, { apiVersion: '2024-06-20' }) : null;
+
+app.use(morgan('combined'));
+app.use(express.json());
+app.use(cors({ origin: allowedOrigin, credentials: true }));
+app.use(session({
+  name: 'drsid',
+  secret: sessionSecret,
+  resave: false,
+  saveUninitialized: true,
+  cookie: {
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 30 * 24 * 3600 * 1000,
+  }
+}));
+
+app.get('/subscription/status', async (req, res) => {
+  try {
+    const sess = req.session;
+    if (sess.subscribed) {
+      return res.json({ subscribed: true });
+    }
+    if (stripe && sess.stripeCustomerId) {
+      try {
+        const subs = await stripe.subscriptions.list({
+          customer: sess.stripeCustomerId,
+          status: 'all',
+          limit: 1,
+        });
+        const active = subs.data.some(s => ['active', 'trialing'].includes(s.status));
+        sess.subscribed = active;
+        return res.json({ subscribed: active });
+      } catch (err) {
+        console.error('Stripe status check failed', err);
+      }
+    }
+    return res.json({ subscribed: false });
+  } catch (err) {
+    console.error('Status error', err);
+    res.status(500).json({ error: 'Failed to determine subscription status' });
+  }
+});
+
+app.get('/subscription/verify', async (req, res) => {
+  try {
+    if (!stripe) return res.status(500).json({ error: 'Stripe not configured' });
+    const sess = req.session;
+    const sessionId = sess.checkoutSessionId || req.query.session_id;
+    if (!sessionId) {
+      return res.status(400).json({ error: 'Missing session id' });
+    }
+    const checkout = await stripe.checkout.sessions.retrieve(sessionId, { expand: ['subscription'] });
+    if (checkout.customer) {
+      sess.stripeCustomerId = checkout.customer as string;
+    }
+    let active = false;
+    const sub = checkout.subscription;
+    if (sub && typeof sub === 'object') {
+      active = ['active', 'trialing'].includes(sub.status);
+    } else if (typeof sub === 'string') {
+      const fetched = await stripe.subscriptions.retrieve(sub);
+      active = ['active', 'trialing'].includes(fetched.status);
+    }
+    sess.subscribed = active;
+    res.json({ subscribed: active });
+  } catch (err) {
+    console.error('Verify error', err);
+    res.status(500).json({ error: 'Failed to verify subscription' });
+  }
+});
+
+app.post('/stripe/create-checkout', async (req, res) => {
+  try {
+    if (!stripe || !priceId) {
+      return res.status(500).json({ error: 'Stripe not configured' });
+    }
+    const checkout = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      line_items: [{ price: priceId, quantity: 1 }],
+      subscription_data: { trial_period_days: 7 },
+      success_url: returnUrl,
+      cancel_url: returnUrl,
+    });
+    req.session.checkoutSessionId = checkout.id;
+    res.json({ id: checkout.id, url: checkout.url });
+  } catch (err) {
+    console.error('Checkout error', err);
+    res.status(500).json({ error: 'Failed to create checkout session' });
+  }
+});
+
+app.listen(port, () => {
+  console.log(`deeprabbit subscription server running on port ${port}`);
+});
+
+export default app;


### PR DESCRIPTION
## Summary
- add Express server handling subscription status, verification, and checkout session creation via Stripe
- configure CORS, sessions, logging, and error handling for secure trial/subscription management
- document server setup and environment variables

## Testing
- `npm run build`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*

------
https://chatgpt.com/codex/tasks/task_e_6898f2e722b8832197adf85d929fc9a7