### PR TITLE
docs: add marketing and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # deeprabbit (PRO)
 
-deeprabbit is a real‑time AI music performance tool. Use natural language styles (prompts) and your MIDI controller to shape evolving music on stage.
+**Fresh tracks. Forged by AI.**
+
+DeepRabbit is a real‑time AI music performance tool. Use natural language styles and your MIDI controller to sculpt evolving tracks on stage.
+
+## Features
+
+- **Real‑time AI performance** – generate and blend musical ideas with zero latency.
+- **Curate & toggle styles** – load up to eight styles, switch them on and off, and map controls for instant changes.
+- **MIDI first** – connect your hardware to shape dynamics, effects, and transitions.
 
 ## Run Locally
 
@@ -19,15 +27,25 @@ Prerequisites: Node.js
    - `VITE_STRIPE_CUSTOMER_PORTAL_URL=https://billing.stripe.com/p/session/...` *(optional direct portal)*
 4. Run: `npm run dev`
 
-## How to use (end users)
+## User Guide
 
-1. Start your 7‑day free trial or continue if subscribed.
-2. Click MIDI in the header and select your controller.
-3. Choose up to 8 styles in Tracks to place on the grid.
-4. Press Play. Move sliders or mapped knobs to blend styles.
-5. Map controls: click “Click to learn” on a slot, turn a knob; do the same in Instruments.
+1. **Start a session** – begin your free trial or sign in with an active subscription.
+2. **Connect MIDI** – click **MIDI** in the header and choose your controller.
+3. **Curate styles** – browse Tracks, add as many styles as you like, then drag up to eight onto the grid.
+4. **Perform live** – press **Play**. Move sliders or mapped knobs to blend styles in real time.
+5. **Toggle on the fly** – enable or disable styles during your set for dynamic transitions.
+6. **Map controls** – select “Click to learn” on a slot, turn a knob, and repeat for instruments or effects.
 
-Tip: Curate many styles in Tracks and toggle which 8 are active per song.
+Tip: Load a larger palette of styles in Tracks and toggle which eight are active per song.
+
+## Troubleshooting
+
+- **No sound?** Ensure your browser tab has audio permission and your speakers are selected.
+- **MIDI device missing?** Verify Web MIDI is supported and that you've granted access. Reconnect the controller and refresh the page.
+- **API key errors?** Confirm `GEMINI_API_KEY` is set in `.env.local` and restart the dev server.
+- **Subscription problems?** Check the URLs in `.env.local` and verify your network connection.
+
+For additional questions see the [FAQ](docs/FAQ.md).
 
 ## Tech
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,19 @@
+# DeepRabbit FAQ
+
+## What is DeepRabbit?
+DeepRabbit is a real-time AI music performance tool that lets you shape evolving tracks with natural language prompts and MIDI hardware.
+
+## How do I curate styles?
+Open the Tracks panel and browse or search for styles. Add as many as you like, then choose up to eight to place on the performance grid.
+
+## Can I toggle styles during a performance?
+Yes. Use the Tracks panel to enable or disable styles in real time. You can also map MIDI controls to quickly toggle slots on and off.
+
+## Do I need a subscription?
+New users can start with a free trial. Afterward, a subscription is required to keep generating tracks.
+
+## My MIDI controller isn't detected. What can I do?
+Ensure your browser supports Web MIDI and that you've granted permissions. Refresh the page or reconnect the controller and try again.
+
+## Where can I get help?
+Check the troubleshooting section in the README or contact support at support@deeprabbit.app.

--- a/marketing/index.html
+++ b/marketing/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>DeepRabbit – Fresh tracks. Forged by AI.</title>
+  <style>
+    body {font-family: Arial, sans-serif; margin: 0; padding: 0; background:#000; color:#fff;}
+    header {text-align: center; padding: 4rem 1rem;}
+    h1 {font-size: 3rem; margin-bottom: 0.5rem;}
+    section {padding: 2rem 1rem; max-width: 800px; margin: 0 auto;}
+    .cta {text-align: center; padding: 3rem 1rem;}
+    a.button {background:#ff3366; color:#fff; padding:1rem 2rem; text-decoration:none; border-radius:4px;}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Fresh tracks. Forged by AI.</h1>
+    <p>DeepRabbit turns your prompts and MIDI moves into live, evolving music.</p>
+  </header>
+
+  <section>
+    <h2>Real-time AI music performance</h2>
+    <p>Generate and blend musical ideas on stage with zero latency. DeepRabbit listens to your MIDI controller and responds instantly.</p>
+  </section>
+
+  <section>
+    <h2>Curate and toggle styles</h2>
+    <p>Browse an ever-growing library of AI-driven styles. Load up to eight at a time and switch them on or off as your set evolves.</p>
+  </section>
+
+  <div class="cta">
+    <a class="button" href="https://deeprabbit.app">Start your free trial</a>
+  </div>
+</body>
+</html>

--- a/marketing/social-media.md
+++ b/marketing/social-media.md
@@ -1,0 +1,17 @@
+# DeepRabbit Social Media Assets
+
+## Twitter / X
+- **Post:** Fresh tracks. Forged by AI. 🎧
+- **Body:** Shape live music with natural language and MIDI control. Try DeepRabbit free for 7 days.
+- **Hashtags:** #AIMusic #LivePerformance #MIDI
+- **Link:** https://deeprabbit.app
+
+## Instagram
+- **Caption:** Fresh tracks. Forged by AI.
+- **Body:** Swipe to see how DeepRabbit blends styles on the fly. Tap the link in bio to start your free trial.
+- **Hashtags:** #AIMusic #ProducerLife #LiveSet
+
+## LinkedIn
+- **Headline:** Fresh tracks. Forged by AI.
+- **Body:** DeepRabbit brings real-time AI composition to the stage. Curate styles, toggle them live, and evolve your sound. Explore the beta today.
+- **Link:** https://deeprabbit.app


### PR DESCRIPTION
## Summary
- add marketing landing page and sample social media posts
- expand README with features, user guide, and troubleshooting
- add FAQ documentation

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898f3e527ec83219c22179010365f22