### PR TITLE
chore: update site domain

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -16,4 +16,4 @@ New users can start with a free trial. Afterward, a subscription is required to 
 Ensure your browser supports Web MIDI and that you've granted permissions. Refresh the page or reconnect the controller and try again.
 
 ## Where can I get help?
-Check the troubleshooting section in the README or contact support at support@deeprabbit.app.
+Check the troubleshooting section in the README or contact support at support@deeprabbit.net.

--- a/marketing/index.html
+++ b/marketing/index.html
@@ -30,7 +30,7 @@
   </section>
 
   <div class="cta">
-    <a class="button" href="https://deeprabbit.app">Start your free trial</a>
+    <a class="button" href="https://deeprabbit.net">Start your free trial</a>
   </div>
 </body>
 </html>

--- a/marketing/social-media.md
+++ b/marketing/social-media.md
@@ -4,7 +4,7 @@
 - **Post:** Fresh tracks. Forged by AI. 🎧
 - **Body:** Shape live music with natural language and MIDI control. Try DeepRabbit free for 7 days.
 - **Hashtags:** #AIMusic #LivePerformance #MIDI
-- **Link:** https://deeprabbit.app
+- **Link:** https://deeprabbit.net
 
 ## Instagram
 - **Caption:** Fresh tracks. Forged by AI.
@@ -14,4 +14,4 @@
 ## LinkedIn
 - **Headline:** Fresh tracks. Forged by AI.
 - **Body:** DeepRabbit brings real-time AI composition to the stage. Curate styles, toggle them live, and evolve your sound. Explore the beta today.
-- **Link:** https://deeprabbit.app
+- **Link:** https://deeprabbit.net

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "deeprabbit — AI-driven live music performance with MIDI control, stems, and style blending.",
   "author": "deeprabbit",
-  "homepage": "https://deeprabbit.app/",
+  "homepage": "https://deeprabbit.net/",
   "license": "Proprietary",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- point public homepage to deeprabbit.net
- switch documentation and marketing links to new deeprabbit.net domain

## Testing
- `npm test` *(fails: Missing script "test" )*

------
https://chatgpt.com/codex/tasks/task_e_6898fc0a1ef88321a85f7ecb9fac60a5